### PR TITLE
Porting work to SFML3

### DIFF
--- a/Basic.h
+++ b/Basic.h
@@ -13,7 +13,7 @@ struct SoftAssetManager {
 
   sf::Font PassFont(std::string filePath) {
     sf::Font theFont;
-    theFont.loadFromFile(filePath);
+    theFont.openFromFile(filePath);
     return theFont;
   }
 
@@ -21,7 +21,7 @@ struct SoftAssetManager {
     sf::Font theFont;
 
     if (num == 1) {
-      theFont.loadFromMemory(montserrat, montserrat_length);
+      theFont.openFromMemory(montserrat, montserrat_length);
     }
 
     return theFont;
@@ -34,27 +34,30 @@ struct AllText {
     asset = new SoftAssetManager();
     theHeaderFont = asset->PassEmbededFont(1);
 
-    theHeaderText.setFont(theHeaderFont);
-    theHeaderText.setCharacterSize(45);
-    theHeaderText.setFillColor(sf::Color::Black);
+    // Create text with the font (hack, but I don't know enough about SFML yet)
+    theHeaderText = new sf::Text(theHeaderFont, "", 45);
+    theHeaderText->setFillColor(sf::Color::Black);
   }
 
-  ~AllText() { delete asset; }
+  ~AllText() { 
+    delete asset; 
+    delete theHeaderText;
+  }
 
   void SetHeaderText(std::string word, sf::Vector2f position) {
-    theHeaderText.setString(word);
-    theHeaderText.setPosition(position);
+    theHeaderText->setString(word);
+    theHeaderText->setPosition(position);
   }
 
   void SetHeaderCharacterSize(int size) {
-    theHeaderText.setCharacterSize(size);
+    theHeaderText->setCharacterSize(size);
   }
 
   void DrawHeaderTextToScreen(sf::RenderWindow &window) {
-    window.draw(theHeaderText);
+    window.draw(*theHeaderText);
   }
 
-  sf::Text theHeaderText;
+  sf::Text *theHeaderText;
 
   sf::Font theHeaderFont;
 
@@ -92,7 +95,7 @@ public:
   virtual bool CanClick(sf::Vector2f mousePosition) {
 
     if (tempText->getGlobalBounds().contains(mousePosition)) {
-      if (sf::Mouse::isButtonPressed(sf::Mouse::Left)) {
+      if (sf::Mouse::isButtonPressed(sf::Mouse::Button::Left)) {
         return true;
       }
     }
@@ -100,9 +103,8 @@ public:
   }
 
   virtual bool CanClick(sf::Event event, sf::Vector2f mousePosition) {
-
-    if (event.type == sf::Event::MouseButtonPressed) {
-      if (event.mouseButton.button == sf::Mouse::Left &&
+    if (const auto* mouseButtonPressed = event.getIf<sf::Event::MouseButtonPressed>()) {
+      if (mouseButtonPressed->button == sf::Mouse::Button::Left &&
           isMousePressed == false) {
         if (tempText->getGlobalBounds().contains(mousePosition)) {
           isMousePressed = true;
@@ -111,8 +113,8 @@ public:
       }
     }
 
-    if (event.type == sf::Event::MouseButtonReleased && currentMouseState) {
-      if (event.mouseButton.button == sf::Mouse::Left) {
+    if (const auto* mouseButtonReleased = event.getIf<sf::Event::MouseButtonReleased>(); mouseButtonReleased && currentMouseState) {
+      if (mouseButtonReleased->button == sf::Mouse::Button::Left) {
         if (tempText->getGlobalBounds().contains(mousePosition)) {
           currentMouseState = false;
           return true;
@@ -126,7 +128,7 @@ public:
   virtual bool CanClickSprite(sf::Vector2f mousePosition) {
 
     if (tempSprite->getGlobalBounds().contains(mousePosition)) {
-      if (sf::Mouse::isButtonPressed(sf::Mouse::Left)) {
+      if (sf::Mouse::isButtonPressed(sf::Mouse::Button::Left)) {
         return true;
       }
     }
@@ -135,8 +137,8 @@ public:
 
   virtual bool CanClickSprite(sf::Event event, sf::Vector2f mousePosition) {
 
-    if (event.type == sf::Event::MouseButtonPressed) {
-      if (event.mouseButton.button == sf::Mouse::Left &&
+    if (const auto* mouseButtonPressed = event.getIf<sf::Event::MouseButtonPressed>()) {
+      if (mouseButtonPressed->button == sf::Mouse::Button::Left &&
           isMousePressed == false) {
         if (tempSprite->getGlobalBounds().contains(mousePosition)) {
           isMousePressed = true;
@@ -145,8 +147,8 @@ public:
       }
     }
 
-    if (event.type == sf::Event::MouseButtonReleased && currentMouseState) {
-      if (event.mouseButton.button == sf::Mouse::Left) {
+    if (const auto* mouseButtonReleased = event.getIf<sf::Event::MouseButtonReleased>(); mouseButtonReleased && currentMouseState) {
+      if (mouseButtonReleased->button == sf::Mouse::Button::Left) {
         if (tempSprite->getGlobalBounds().contains(mousePosition)) {
           currentMouseState = false;
           return true;

--- a/Game.h
+++ b/Game.h
@@ -318,13 +318,13 @@ private:
   }
 
   void GameFixedUpdate() {
-    while (screen.window.pollEvent(screen.event)) {
-      if (screen.event.type == sf::Event::Closed) {
+    while (auto event = screen.window.pollEvent()) {
+      if (event->getIf<sf::Event::Closed>()) {
         screen.window.close();
       }
 
-      if (screen.event.type == sf::Event::KeyPressed) {
-        if (screen.event.key.code == sf::Keyboard::W &&
+      if (const auto* keyPressed = event->getIf<sf::Event::KeyPressed>()) {
+        if (keyPressed->code == sf::Keyboard::Key::W &&
             currentBounds != Bounds::Up) {
           currentBounds = 0;
           direction[0] = false;
@@ -333,7 +333,7 @@ private:
           direction[2] = true;
         }
 
-        if (screen.event.key.code == sf::Keyboard::S &&
+        if (keyPressed->code == sf::Keyboard::Key::S &&
             currentBounds != Bounds::Down) {
           currentBounds = 0;
           direction[0] = false;
@@ -342,7 +342,7 @@ private:
           direction[3] = true;
         }
 
-        if (screen.event.key.code == sf::Keyboard::A &&
+        if (keyPressed->code == sf::Keyboard::Key::A &&
             currentBounds != Bounds::Left) {
           currentBounds = 0;
           direction[0] = false;
@@ -351,7 +351,7 @@ private:
           direction[1] = true;
         }
 
-        if (screen.event.key.code == sf::Keyboard::D &&
+        if (keyPressed->code == sf::Keyboard::Key::D &&
             currentBounds != Bounds::Right) {
 
           currentBounds = 0;
@@ -384,16 +384,14 @@ private:
   }
 
   void TitleFixedUpdate() {
-    while (screen.window.pollEvent(screen.event)) {
-      if (screen.event.type == sf::Event::Closed) {
+    while (auto event = screen.window.pollEvent()) {
+      if (event->getIf<sf::Event::Closed>()) {
         screen.window.close();
       }
 
-      if(screen.FixedUpdateButtons())
-      {
+      if (screen.titleButton.CanClick(*event, screen.mousePos)) {
         state.currentGameState = state.Game;
       }
-      
     }
   }
 
@@ -419,12 +417,11 @@ private:
   }
 
   void EndFixedUpdate() {
-    while (screen.window.pollEvent(screen.event)) {
-      if (screen.event.type == sf::Event::Closed) {
+    while (auto event = screen.window.pollEvent()) {
+      if (event->getIf<sf::Event::Closed>()) {
         screen.window.close();
       }
-      if (screen.FixedUpdateEndButtons()) 
-      {
+      if (screen.endButton.CanClick(*event, screen.mousePos)) {
         Reset();
         state.currentGameState = state.Game;     
       }

--- a/Window.h
+++ b/Window.h
@@ -114,11 +114,11 @@ struct Screen {
   void SetButtons() {
     startText.SetHeaderText("Press Start", sf::Vector2f(200, 200));
     endText.SetHeaderText("Try Again?", sf::Vector2f(200, 200));
-    titleButton = Dinzai::Button(startText.theHeaderText);
-    endButton = Dinzai::Button(endText.theHeaderText);
+    titleButton = Dinzai::Button(*startText.theHeaderText);
+    endButton = Dinzai::Button(*endText.theHeaderText);
   }
 
-  Screen() : window(sf::VideoMode(ScreenWidth, ScreenHeight), "Snake") {
+  Screen() : window(sf::VideoMode(sf::Vector2u(ScreenWidth, ScreenHeight)), "Snake") {
     chunks = new LinkedChunk();
     SetButtons();
   }
@@ -126,9 +126,7 @@ struct Screen {
   void UpdateButtons() { titleButton.CheckCollision(mousePos); }
 
   int FixedUpdateButtons() {
-    if (titleButton.CanClick(event, mousePos)) {
-      return 1;
-    }
+    // This method is deprecated - use titleButton.CanClick directly in event loop
     return 0;
   }
 
@@ -137,9 +135,7 @@ struct Screen {
   void UpdateEndButtons() { endButton.CheckCollision(mousePos); }
 
   bool FixedUpdateEndButtons() {
-    if (endButton.CanClick(event, mousePos)) {
-      return true;
-    }
+    // This method is deprecated - use endButton.CanClick directly in event loop
     return false;
   }
 
@@ -205,8 +201,8 @@ struct Screen {
     for (int i = 0; i < worldWidth; i++) {
       for (int j = 0; j < worldHeight; j++) {
         sf::RectangleShape chunk = MakeChunk(chunkSize);
-        chunk.setPosition(i * chunk.getSize().x + offset,
-                          j * chunk.getSize().y + offset);
+        chunk.setPosition(sf::Vector2f(i * chunk.getSize().x + offset,
+                          j * chunk.getSize().y + offset));
         chunks->AddEntity(chunk);
       }
     }
@@ -216,7 +212,6 @@ struct Screen {
 
   sf::Clock mainClock;
   sf::Time deltaTime;
-  sf::Event event;
   sf::RenderWindow window;
   LinkedChunk *chunks;
 


### PR DESCRIPTION
This work includes, but is not limited to:
- Rename font loading methods
- Redid event handling
    - SFML 3 uses variant-based events instead of union-based events
    - Using `getIf<sf::Event>()` instead of `if (event.type == ...)`
    - Modified `pollEvent()` to return `std::optional<sf::Event>` instead of taking reference
    - Updated event member access - No more `event.mouseButton.button` or `event.key.code`
    - Events are handled directly in the polling loops
- Fixed buttons
    - Fixed Button constructor calls - Updated to work with pointer-based text objects
    - Updated event handling in Game logic - Modified game state event loops to work with new event system
- Fixup namespace changes between SFML 2 and 3
- Fixup constructors to align with SFML 3
    - Removed default constructor
    - Text creation now uses `new sf::Text(font, string, characterSize)`
- Changed to pointer-based approach in many places
- Added text pointer to destructor to avoid memory leak
- Added `vector2u` and `vector2f` use in some places